### PR TITLE
[feature] 다운로드 완료 후 크롬 알림 기능 추가

### DIFF
--- a/script.js
+++ b/script.js
@@ -827,6 +827,10 @@ async function downloadNovel(
 							`"${title}" 다운로드 시작`,
 							`${completedEpisodes}화가 ZIP 파일로 저장됩니다.`,
 						);
+						showChromeNotification(
+							`"${title}" 다운로드 시작`,
+							`${completedEpisodes}화가 ZIP 파일로 저장됩니다.`,
+						);
 						document.body.removeChild(completionDialog);
 					});
 				} else {
@@ -838,6 +842,10 @@ async function downloadNovel(
 
 					// 다운로드 클릭 후 성공 알림 표시
 					showNotification(
+						`"${title}" 다운로드 시작`,
+						`${completedEpisodes}화가 텍스트 파일로 저장됩니다.`,
+					);
+					showChromeNotification(
 						`"${title}" 다운로드 시작`,
 						`${completedEpisodes}화가 텍스트 파일로 저장됩니다.`,
 					);
@@ -941,6 +949,36 @@ function showNotification(title, message) {
 		notification.style.transition = "opacity 0.3s";
 		setTimeout(() => document.body.removeChild(notification), 300);
 	}, 5000);
+}
+
+function showChromeNotification(title, message) {
+	if (!("Notification" in window)) {
+		console.log("[showChromeNotification] 이 브라우저는 데스크톱 알림을 지원하지 않습니다");
+		return;
+	}
+	
+	if (Notification.permission === "granted") {
+		const notification = new Notification(title, {
+			body: message,
+			icon: "https://raw.githubusercontent.com/yeorinhieut/novel-dl/main/icon.png"
+		});
+		
+		// 5초 후 자동 종료
+		setTimeout(() => notification.close(), 5000);
+	} 
+	else if (Notification.permission !== "denied") {
+		Notification.requestPermission().then(permission => {
+			if (permission === "granted") {
+				const notification = new Notification(title, {
+					body: message,
+					icon: "https://raw.githubusercontent.com/yeorinhieut/novel-dl/main/icon.png"
+				});
+				
+				// 5초 후 자동 종료
+				setTimeout(() => notification.close(), 5000);
+			}
+		});
+	}
 }
 
 function extractTitle() {


### PR DESCRIPTION
# 다운로드 완료 후 크롬 알림 기능 추가

다운로드 완료 시 Chrome 브라우저 알림을 보내는 기능을 추가했습니다.

## 변경사항
- Chrome 알림 API를 사용하여 `showChromeNotification` 함수 추가
- 다운로드 완료 시 Chrome 알림 호출
- 기존 웹페이지 내 알림은 유지

## 기능 설명
- 브라우저가 알림을 지원하는지 확인
- 알림 권한이 이미 부여되었는지 확인
- 권한이 없는 경우 사용자에게 권한 요청
- 알림에 아이콘 추가
- 5초 후 자동으로 알림 닫힘

## 테스트
- 다운로드 버튼 클릭 시 Chrome 알림이 정상적으로 표시됨
- 알림 권한 요청이 필요한 경우 적절히 처리됨
- 기존 웹페이지 내 알림과 함께 작동

Link to Devin run: https://app.devin.ai/sessions/9dd0846fc8984fd88bea8ca2a99fbcf3
Requested by: 김준형 (res1235@gmail.com)
